### PR TITLE
Add an Ansible role to set up log watcher and processor progams as systemd services

### DIFF
--- a/ansible/roles/rg_instructor_analytics_log_collector/defaults/main.yml
+++ b/ansible/roles/rg_instructor_analytics_log_collector/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+
+venv_path: "{{ edxapp_venv_dir }}/src/rg-instructor-analytics-log-collector"
+rg_instructor_analytics_user: "rg_instructor_analytics"
+rg_analytics_log_collector_app_dir: "{{ edxapp_app_dir }}/rg_analytics_log_collector"
+rg_analytics_log_collector_workers:
+  - program_name: "log_watcher"
+    command: "run_log_watcher.py"
+    path: "{{ venv_path }}"
+  - program_name: "processor"
+    command: "run_processors.py -a enrollment"
+    path: "{{ venv_path }}"

--- a/ansible/roles/rg_instructor_analytics_log_collector/meta/main.yml
+++ b/ansible/roles/rg_instructor_analytics_log_collector/meta/main.yml
@@ -1,0 +1,5 @@
+---
+dependencies:
+  - common
+  - common_vars
+  - edxapp

--- a/ansible/roles/rg_instructor_analytics_log_collector/tasks/main.yml
+++ b/ansible/roles/rg_instructor_analytics_log_collector/tasks/main.yml
@@ -1,0 +1,114 @@
+---
+# Run rg_instructor_analytics_log_collector Python processes
+# Manage as services under systemd (not Supervisor, in order to access tracking log)
+# Must be on edxapp-server to have access to tracking.log
+
+# Example play:
+#
+# - name: Set up Raccoon Gang Instructor Analytics Log Collector programs
+#   hosts: edxapp-server
+#   sudo: True
+#   gather_facts: True
+#   roles:
+#     - rg_instructor_analytics_log_collector
+#
+
+- name: RG Analytics Log Collector - Include vars_files
+  # paths assume this role is installed under configuration/playbooks/roles
+  include_vars:
+    - "../common_vars/defaults/main.yml"
+    - "../common/defaults/main.yml"
+    - "../edxapp/defaults/main.yml"
+  tags:
+    - "install"
+    - "install:configuration"
+    - "rg_instructor_analytics"
+
+- name: RG Analytics Log Collector - Create user
+  user:
+    name: "{{ rg_instructor_analytics_user }}"
+    groups:
+      - edxapp
+      - www-data
+      - adm  # for access to tracking logs
+    createhome: false
+    home: "{{ rg_analytics_log_collector_app_dir }}"
+    shell: /bin/false
+    system: true
+    generate_ssh_key: false
+    state: present
+  tags:
+    - "install"
+    - "install:configuration"
+    - "rg_instructor_analytics"
+
+- name: RG Analytics Log Collector - Create directory for programs
+  file:
+    path: "{{ rg_analytics_log_collector_app_dir }}"
+    state: directory
+    owner: "{{ rg_instructor_analytics_user }}"
+    group: "{{ rg_instructor_analytics_user }}"
+    mode: 0775
+  tags:
+    - "install"
+    - "install:configuration"
+    - "rg_instructor_analytics"
+
+- name: RG Analytics Log Collector - Write shell wrapper for programs
+  template:
+    src: "rg_instructor_analytics_worker.sh.j2"
+    dest: "{{ rg_analytics_log_collector_app_dir }}/{{ item.program_name }}.sh"
+    mode: "0775"
+  become_user: "{{ rg_instructor_analytics_user }}"
+  with_items: "{{ rg_analytics_log_collector_workers }}"
+  tags:
+    - "install"
+    - "install:configuration"
+    - "rg_instructor_analytics"
+
+- name: RG Analytics Log Collector - Add systemd configurations on 16.04
+  template:
+    src: "rg_instructor_analytics.service.j2"
+    dest: "/etc/systemd/system/rg_instructor_analytics.{{ item.program_name }}.service"
+  with_items: "{{ rg_analytics_log_collector_workers }}"
+  when: ansible_distribution_release == 'xenial'
+  tags:
+    - "install"
+    - "install:configuration"
+    - "rg_instructor_analytics"
+
+- name: RG Analytics Log Collector - Enable systemd unit on 16.04
+  systemd:
+    name: "rg_instructor_analytics.{{ item.program_name }}"
+    enabled: true
+    daemon_reload: true
+  with_items: "{{ rg_analytics_log_collector_workers }}"
+  when: ansible_distribution_release == 'xenial'
+  tags:
+    - "install"
+    - "install:configuration"
+    - "rg_instructor_analytics"
+
+- name: RG Analytics Log Collector - Stop services
+  service:
+    name: "rg_instructor_analytics.{{ item.program_name }}"
+    state: stopped
+  with_items: "{{ rg_analytics_log_collector_workers }}"
+  tags:
+    - "install"
+    - "install:configuration"
+    - "rg_instructor_analytics"
+    - "manage"
+    - "manage:stop"
+
+- name: RG Analytics Log Collector - Start services
+  service:
+    name: "rg_instructor_analytics.{{ item.program_name }}"
+    state: started
+  with_items: "{{ rg_analytics_log_collector_workers }}"
+  tags:
+    - "install"
+    - "install:configuration"
+    - "rg_instructor_analytics"
+    - "manage"
+    - "manage:stop"

--- a/ansible/roles/rg_instructor_analytics_log_collector/templates/rg_instructor_analytics.service.j2
+++ b/ansible/roles/rg_instructor_analytics_log_collector/templates/rg_instructor_analytics.service.j2
@@ -1,0 +1,18 @@
+# {{ ansible_managed }}
+
+[Unit]
+Description=RG Instructor Analytics {{ item.program_name }}
+After=network.target
+Documentation=https://github.com/raccoongang/rg_instructor_analytics_log_collector/tree/washington_university
+
+[Service]
+User={{ rg_instructor_analytics_user }}
+WorkingDirectory={{ rg_analytics_log_collector_app_dir }}
+ExecStart={{ rg_analytics_log_collector_app_dir }}/{{ item.program_name }}.sh
+Restart=always
+
+# Setting Restart interval to be 3 seconds
+# because systemd stops restarting if the service fails to restart
+# more than 5 times within a period of 10 seconds.
+# https://www.freedesktop.org/software/systemd/man/systemd.unit.html#StartLimitIntervalSec=
+RestartSec=3

--- a/ansible/roles/rg_instructor_analytics_log_collector/templates/rg_instructor_analytics_worker.sh.j2
+++ b/ansible/roles/rg_instructor_analytics_log_collector/templates/rg_instructor_analytics_worker.sh.j2
@@ -3,4 +3,4 @@
 # {{ ansible_managed }}
 
 source {{ edxapp_app_dir}}/edxapp_env
-DJANGO_SETTINGS_MODULE=lms.envs.aws_appsembler SERVICE_VARIANT=lms /edx/bin/python.edxapp {{ item.path }}/{{ item.command }}
+DJANGO_SETTINGS_MODULE=lms.envs.aws SERVICE_VARIANT=lms /edx/bin/python.edxapp {{ item.path }}/{{ item.command }}

--- a/ansible/roles/rg_instructor_analytics_log_collector/templates/rg_instructor_analytics_worker.sh.j2
+++ b/ansible/roles/rg_instructor_analytics_log_collector/templates/rg_instructor_analytics_worker.sh.j2
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# {{ ansible_managed }}
+
+source {{ edxapp_app_dir}}/edxapp_env
+DJANGO_SETTINGS_MODULE=lms.envs.aws_appsembler SERVICE_VARIANT=lms /edx/bin/python.edxapp {{ item.path }}/{{ item.command }}


### PR DESCRIPTION
log_watcher and processor programs should be configurable and repeatable.  Using a service gives the ability to start at system boot, manage and restart if there are issues.  They need to be run as systemd services and not, say, Supervisord programs since Open edX's Supervisord runs as user `www-data`, which doen'st have permissions on `/edx/var/logs/tracking`.  This could probably be rebased off of master at whatever point the features developed for the University of Washington are brought into that branch.

